### PR TITLE
Fix setting new time on non-live widgets

### DIFF
--- a/lib/analog_clock.dart
+++ b/lib/analog_clock.dart
@@ -149,7 +149,6 @@ class _AnalogClockState extends State<AnalogClock> {
 
     if (!widget.isLive && widget.datetime != oldWidget.datetime) {
       datetime = widget.datetime ?? DateTime.now();
-      datetime = DateTime.now();
     }
   }
 }


### PR DESCRIPTION
Before this change, the now-removed line just unconditionally overwrote the value set on the line before it.

Fixes #16.